### PR TITLE
Implemented automatic documentation generation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,20 +7,43 @@ on:
     paths:
       - 'kaskadi.js'
       - 'functions/**'
+      - 'docs/**'
       - 'package.json'
 jobs:
-  publish:
+  generate-docs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Install dependencies
-      run: npm i
-    - name: Execute tests
-      run: npm test
+    - name: Import GPG key
+      uses: crazy-max/ghaction-import-gpg@v2
+      with:
+        git_user_signingkey: true
+        git_commit_gpgsign: true
+      env:
+        GPG_PRIVATE_KEY: ${{ secrets.KASKADI_BOT_GPG_PRIVATE_KEY }}
+        PASSPHRASE: ${{ secrets.KASKADI_BOT_GPG_PRIVATE_PASSPHRASE }}
+    - name: Generate documentation
+      uses: kaskadi/action-generate-docs@master
+      with:
+        type: package
+        template: docs/template.md
+  publish:
+    runs-on: ubuntu-latest
+    needs: generate-docs
+    steps:
+    - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
       with:
         node-version: 12
         registry-url: https://registry.npmjs.org/
+    - name: Pull latest commit
+      run: |
+        git config pull.rebase false
+        git pull
+    - name: Install dependencies
+      run: npm i
+    - name: Tests
+      run: npm test
     - name: Publish to NPM
       uses: JS-DevTools/npm-publish@v1
       with:

--- a/docs/template.md
+++ b/docs/template.md
@@ -1,0 +1,24 @@
+![](https://img.shields.io/github/package-json/v/kaskadi/kaskadi-cli)
+![](https://img.shields.io/badge/code--style-standard-blue)
+![](https://img.shields.io/github/license/kaskadi/kaskadi-cli?color=blue)
+
+**GitHub Actions workflows status**
+
+[![](https://img.shields.io/github/workflow/status/kaskadi/kaskadi-cli/publish?label=publish&logo=npm)](https://github.com/kaskadi/kaskadi-cli/actions?query=workflow%3Apublish)
+[![](https://img.shields.io/github/workflow/status/kaskadi/kaskadi-cli/build?label=build&logo=mocha)](https://github.com/kaskadi/kaskadi-cli/actions?query=workflow%3Abuild)
+
+**CodeClimate**
+
+[![](https://img.shields.io/codeclimate/maintainability/kaskadi/kaskadi-cli?label=maintainability&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/kaskadi-cli)
+[![](https://img.shields.io/codeclimate/tech-debt/kaskadi/kaskadi-cli?label=technical%20debt&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/kaskadi-cli)
+[![](https://img.shields.io/codeclimate/coverage/kaskadi/kaskadi-cli?label=test%20coverage&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/kaskadi-cli)
+
+**LGTM**
+
+[![](https://img.shields.io/lgtm/grade/javascript/github/kaskadi/kaskadi-cli?label=code%20quality&logo=LGTM)](https://lgtm.com/projects/g/kaskadi/kaskadi-cli/?mode=list&logo=LGTM)
+
+****
+
+{{>main}}
+
+In order to know which commands are available in `kaskadi-cli` please run `kaskadi [--help, -h]` in your terminal.

--- a/kaskadi.js
+++ b/kaskadi.js
@@ -8,7 +8,7 @@ program
   .version(require('./package.json').version)
 program
   .command('init <type>')
-  .description('initialize a repository. <type> argument defines which kind of template the repository is following. Valid values are: action, api, lambda, element and layer.')
+  .description('initialize a repository. <type> argument defines which kind of template the repository is following. Valid values are: action, api, lambda, element, layer and package.')
   .action(require('./functions/init/init.js'))
 program
   .command('render')


### PR DESCRIPTION
**Changes description**
Implemented automatic documentation generation using `action-generate-docs` action inside of `publish` workflow.

**New features**
- _docs template:_ template for documentation located under `docs/template.md`

**Updated features**
- _`publish` workflow:_ added a documentation generation job prior `publish`
- _entry point:_ added `package` as valid value for `init` command