### PR TITLE
Implemented static code analysis

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,29 @@ on:
       - 'functions/**'
       - 'package.json'
 jobs:
+  # scan code using CodeQL
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - 'javascript'
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1
   coverage:
     runs-on: ubuntu-latest
+    needs: analyze
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,8 +10,29 @@ on:
       - 'docs/**'
       - 'package.json'
 jobs:
+  # scan code using CodeQL
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - 'javascript'
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1
   generate-docs:
     runs-on: ubuntu-latest
+    needs: analyze
     steps:
     - uses: actions/checkout@v2
     - name: Import GPG key

--- a/docs/template.md
+++ b/docs/template.md
@@ -4,18 +4,14 @@
 
 **GitHub Actions workflows status**
 
-[![](https://img.shields.io/github/workflow/status/kaskadi/kaskadi-cli/publish?label=publish&logo=npm)](https://github.com/kaskadi/kaskadi-cli/actions?query=workflow%3Apublish)
-[![](https://img.shields.io/github/workflow/status/kaskadi/kaskadi-cli/build?label=build&logo=mocha)](https://github.com/kaskadi/kaskadi-cli/actions?query=workflow%3Abuild)
+[![Build workflow status](https://img.shields.io/github/workflow/status/kaskadi/kaskadi-cli/build?label=build&logo=mocha)](https://github.com/kaskadi/kaskadi-cli/actions?query=workflow%3Abuild)
+[![Publish workflow status](https://img.shields.io/github/workflow/status/kaskadi/kaskadi-cli/publish?label=publish&logo=npm)](https://github.com/kaskadi/kaskadi-cli/actions?query=workflow%3Apublish)
 
 **CodeClimate**
 
 [![](https://img.shields.io/codeclimate/maintainability/kaskadi/kaskadi-cli?label=maintainability&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/kaskadi-cli)
 [![](https://img.shields.io/codeclimate/tech-debt/kaskadi/kaskadi-cli?label=technical%20debt&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/kaskadi-cli)
 [![](https://img.shields.io/codeclimate/coverage/kaskadi/kaskadi-cli?label=test%20coverage&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/kaskadi-cli)
-
-**LGTM**
-
-[![](https://img.shields.io/lgtm/grade/javascript/github/kaskadi/kaskadi-cli?label=code%20quality&logo=LGTM)](https://lgtm.com/projects/g/kaskadi/kaskadi-cli/?mode=list&logo=LGTM)
 
 ****
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kaskadi-cli",
-  "version": "1.5.2",
+  "version": "1.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kaskadi-cli",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kaskadi-cli",
-  "version": "1.5.2",
+  "version": "1.6.1",
   "description": "",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kaskadi-cli",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
**Changes description**
Added GitHub official static code analysis (via `CodeQL`, same as `LGTM`) inside of `build` and `publish` workflow.

**Updated features**
- _`build`/`publish` workflow:_ added static code analysis for vulnerability as a first step of the workflow. If this steps fails, the downstream steps will not run. Any vulnerabilities will be reported by the code analysis actions inside of the `Security` tab of the repository
- _documentation template:_ updated badges to remove `LGTM` badges and add alternative text.