### PR TITLE
Initial implementation of remote module

### DIFF
--- a/functions/remote/add/index.js
+++ b/functions/remote/add/index.js
@@ -1,0 +1,5 @@
+const { spawnSync } = require('child_process')
+
+module.exports = ({ name, ip, path }) => {
+  spawnSync('git', ['remote', 'add', name, `ssh://git@${ip}${path}`], { stdio: 'inherit' })
+}

--- a/functions/remote/add/questions.js
+++ b/functions/remote/add/questions.js
@@ -1,0 +1,38 @@
+const { validate, filter } = require('../prompt-defaults.js')
+
+module.exports = [
+  {
+    type: 'input',
+    name: 'name',
+    message: 'Desired name of the remote',
+    validate: validate('Please provide a remote name'),
+    filter
+  },
+  {
+    type: 'input',
+    name: 'ip',
+    message: 'IP of the remote server',
+    validate: input => {
+      input = filter(input)
+      const ipRegexp = /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/
+      return ipRegexp.test(input) || 'Please provide a valid IP address'
+    },
+    filter
+  },
+  {
+    type: 'input',
+    name: 'path',
+    message: 'Absolute path to the remote on server',
+    validate: validate('Please provide a path'),
+    filter: input => {
+      let answer = filter(input)
+      if (answer.slice(-4) !== '.git') {
+        answer = answer + '.git'
+      }
+      if (answer.charAt(0) !== '/') {
+        answer = '/' + answer
+      }
+      return answer
+    }
+  }
+]

--- a/functions/remote/create/index.js
+++ b/functions/remote/create/index.js
@@ -1,0 +1,1 @@
+module.exports = console.log

--- a/functions/remote/create/questions.js
+++ b/functions/remote/create/questions.js
@@ -1,0 +1,1 @@
+module.exports = []

--- a/functions/remote/deploy/index.js
+++ b/functions/remote/deploy/index.js
@@ -2,5 +2,5 @@ const { spawnSync } = require('child_process')
 
 module.exports = ({ remote, branch, sshPath, port }) => {
   process.env.GIT_SSH_COMMAND = `ssh -i ${sshPath} -p ${port} -o IdentitiesOnly=yes`
-  spawnSync('git', ['push', '--dry-run', remote, branch], { stdio: 'inherit' })
+  spawnSync('git', ['push', remote, branch], { stdio: 'inherit' })
 }

--- a/functions/remote/deploy/index.js
+++ b/functions/remote/deploy/index.js
@@ -1,0 +1,6 @@
+const { spawnSync } = require('child_process')
+
+module.exports = ({ remote, branch, sshPath, port }) => {
+  process.env.GIT_SSH_COMMAND = `ssh -i ${sshPath} -p ${port} -o IdentitiesOnly=yes`
+  spawnSync('git', ['push', '--dry-run', remote, branch], { stdio: 'inherit' })
+}

--- a/functions/remote/deploy/questions.js
+++ b/functions/remote/deploy/questions.js
@@ -1,0 +1,41 @@
+const remotes = require('./utils/get-remotes.js')()
+
+if (remotes.length === 0) {
+  console.log('WARN: no remote other than origin has been found for this repository, aborting...')
+  process.exit()
+}
+
+const { filter } = require('../prompt-defaults.js')
+
+module.exports = [
+  {
+    type: 'list',
+    name: 'remote',
+    message: 'Remote to deploy to',
+    choices: remotes
+  },
+  {
+    type: 'list',
+    name: 'branch',
+    message: 'Branch to deploy',
+    choices: require('./utils/get-branches.js')()
+  },
+  {
+    type: 'list',
+    name: 'sshPath',
+    message: 'SSH key to be used for authentication',
+    choices: require('./utils/get-keys.js')(),
+    filter: input => `${require('./utils/get-ssh-root.js')()}/${input}`
+  },
+  {
+    type: 'input',
+    name: 'port',
+    message: 'Port to be used for SSH authentication',
+    default: '22',
+    validate: input => {
+      input = Number(filter(input))
+      return isNaN(input) || input <= 0 ? 'Please provide a valid port (stricly positive number)' : true
+    },
+    filter
+  }
+]

--- a/functions/remote/deploy/utils/get-branches.js
+++ b/functions/remote/deploy/utils/get-branches.js
@@ -1,0 +1,9 @@
+const { spawnSync } = require('child_process')
+
+module.exports = () => {
+  return spawnSync('git', ['branch'])
+    .stdout.toString().trim()
+    .slice(1)
+    .split('\n')
+    .map(line => line.trim())
+}

--- a/functions/remote/deploy/utils/get-keys.js
+++ b/functions/remote/deploy/utils/get-keys.js
@@ -1,0 +1,11 @@
+const { readdirSync } = require('fs')
+const root = require('./get-ssh-root.js')()
+
+module.exports = () => {
+  const excludedFiles = ['known_hosts']
+  const filterHandler = key => key.slice(-3) !== 'pub' &&
+    key.charAt(0) !== '.' &&
+    !excludedFiles.includes(key)
+  return readdirSync(root)
+    .filter(filterHandler)
+}

--- a/functions/remote/deploy/utils/get-remotes.js
+++ b/functions/remote/deploy/utils/get-remotes.js
@@ -1,0 +1,9 @@
+const { spawnSync } = require('child_process')
+
+module.exports = () => {
+  return spawnSync('git', ['remote'])
+    .stdout.toString().trim()
+    .split('\n')
+    .filter(line => line !== 'origin')
+    .map(line => line.trim())
+}

--- a/functions/remote/deploy/utils/get-ssh-root.js
+++ b/functions/remote/deploy/utils/get-ssh-root.js
@@ -1,0 +1,2 @@
+const homedir = require('os').homedir()
+module.exports = () => `${homedir}/.ssh`

--- a/functions/remote/prompt-defaults.js
+++ b/functions/remote/prompt-defaults.js
@@ -1,0 +1,7 @@
+const validate = errMsg => input => {
+  input = filter(input)
+  return !!input || errMsg
+}
+const filter = input => input.trim()
+
+module.exports = { validate, filter }

--- a/functions/remote/remote.js
+++ b/functions/remote/remote.js
@@ -1,0 +1,11 @@
+const validOps = ['create', 'add', 'deploy']
+const inquirer = require('inquirer')
+
+module.exports = async (op) => {
+  if (!validOps.includes(op)) {
+    console.log(`ERROR: ${op} is not a valid operation for the remote module...`)
+  } else {
+    await inquirer.prompt(require(`./${op}/questions.js`))
+      .then(require(`./${op}/index.js`))
+  }
+}

--- a/kaskadi.js
+++ b/kaskadi.js
@@ -20,8 +20,8 @@ program
   .description('enable Snyk monitoring for your repository')
   .action(require('./functions/snyk/monitor/monitor.js'))
 program
-  .command('remote <type>')
-  .description('interact with a remote repository. <type> argument defines which kind of action we would like to perform on this remote repository. Valid values are: create, add, deploy.')
+  .command('remote <action>')
+  .description('interact with a remote repository. <action> argument defines which kind of action we would like to perform on this remote repository. Valid values are: create, add, deploy.')
   .action(require('./functions/remote/remote.js'))
 
 program.parse(process.argv)

--- a/kaskadi.js
+++ b/kaskadi.js
@@ -19,5 +19,9 @@ program
   .command('snyk-monitor')
   .description('enable Snyk monitoring for your repository')
   .action(require('./functions/snyk/monitor/monitor.js'))
+program
+  .command('remote <type>')
+  .description('interact with a remote repository. <type> argument defines which kind of action we would like to perform on this remote repository. Valid values are: create, add, deploy.')
+  .action(require('./functions/remote/remote.js'))
 
 program.parse(process.argv)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kaskadi-cli",
   "version": "1.6.5",
   "description": "",
-  "main": "index.js",
+  "main": "kaskadi.js",
   "bin": {
     "kaskadi": "./kaskadi.js"
   },


### PR DESCRIPTION
**Changes description**
Started implementing a `remote` module (called via `kaskadi remote <action>`). This module is there to help manipulating remote repositories on a server.

**New features**
- `remote add`: this function allows user to quickly add a remote to their local repository. It'll prompt user for various information regarding the remote (f.e. remote name, IP of server, etc.) and then automatically add the defined remote to the local repository
- `remote deploy`: this function allows user to easily deploy to a remote. It'll grant user the ability to select a remote to deploy to (excluding `origin` for now), the branch that should be deployed as well as the SSH key/port to use for the operation. As of now the module only looks for SSH keys in the default Linux SSH folder (`~/.ssh`)

**Updated features**
- fixed package entry point (was `index.js` instead of `kaskadi.js`)
- `kaskadi.js`: added command for `remote` module

**Notes**
- incoming support for `remote create` which should allow a user to automatically setup a remote repository on a server as well as setup everything on the server to be able to connect and push to this remote repository from the user's local machine
- those functions assume that a properly setup `git` user is available for performing operations on the server. If not, the functions will fail!